### PR TITLE
chore: fix review feedback (git exec safety, cache dir, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,8 @@ Browser → Hono Server (Port 3001)
 
 ### Development Mode
 
-- TypeScript/TSX files served via Rsbuild dev server with HMR
-- CSS is processed with Tailwind CSS v4
-- Hot reload enabled for rapid development
+- Current dev flow runs a local build then starts the Node server.
+- For live edits, re-run `pnpm run dev` or wire up `rsbuild dev` if desired.
 
 ### Production Mode
 
@@ -220,10 +219,10 @@ Tailwind CSS v4 runs via PostCSS during build and dev; no manual step required.
 
 ## Documentation
 
-- [Architecture](./docs/ARCHITECTURE.md) - System design and technical details
-- [Implementation Guide](./docs/IMPLEMENTATION.md) - Step-by-step setup instructions
-- [API Types](./src/lib/api/types.ts) - TypeScript type definitions
-- [Server Documentation](./src/server/README.md) - Server implementation details
+- API Types: `src/lib/api/types.ts`
+- Server entry: `src/server/index.ts`
+- Project routes: `src/server/integrated-project-routes.ts`
+- GitHub integration client: `src/server/github/gh-cli.ts`
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:server": "node server-dist/index.js",
     "dev:build-serve": "rsbuild build && rslib build && node server-dist/index.js",
     "dev:full": "rsbuild build && rslib build && node server-dist/index.js",
-    "build": "rsbuild build && rslib build && (cp -r data server-dist/ 2>/dev/null || true)",
+    "build": "rsbuild build && rslib build",
     "start": "npx kill-port 3001 && cd server-dist && node index.js",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,css,md}\"",

--- a/src/server/github/cache.ts
+++ b/src/server/github/cache.ts
@@ -202,7 +202,7 @@ const warmRecords = new Map<string, WarmRecord>()
 let warmTimer: NodeJS.Timeout | null = null
 
 const cacheRoot = () =>
-  process.env["OPENCODE_GITHUB_CACHE_DIR"] ?? path.resolve(process.cwd(), "data/github-cache")
+  process.env["OPENCODE_GITHUB_CACHE_DIR"] ?? path.resolve(process.cwd(), ".cache/github")
 
 const ensureDirectory = async (dir: string) => {
   await fs.mkdir(dir, { recursive: true })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -57,7 +57,8 @@ export function createServer(config: ServerConfig = {}) {
   // - bodyTimeout: 0 disables per-chunk inactivity timeout (important for LLM streams)
   // - headersTimeout: 0 disables header timeout for slow backends
   // - keepAlive improves reuse when many requests are made
-  const streamingAgent = new Agent({
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const streamingAgent: Agent = new Agent({
     connect: { timeout: 30_000 },
     // Disable per-chunk inactivity and header timeouts for long-lived streams
     bodyTimeout: 0,
@@ -66,9 +67,10 @@ export function createServer(config: ServerConfig = {}) {
     keepAliveTimeout: 60_000,
     keepAliveMaxTimeout: 60_000,
   } as any)
+  /* eslint-enable @typescript-eslint/no-explicit-any */
 
   // Error handling middleware - must be first
-  app.onError((err, c) => {
+  app.onError((err: Error & { message?: string }, c: Context) => {
     log.error("Request error:", err)
 
     // Handle JSON parse errors
@@ -164,7 +166,7 @@ export function createServer(config: ServerConfig = {}) {
       })
     } catch (err: unknown) {
       // Map common undici errors to a quiet response; avoid noisy logs
-      const e = err as any
+      const e = err as { code?: string; cause?: { code?: string }; message?: string }
       const code = e?.code || e?.cause?.code
       const msg: string = e?.message || "fetch error"
 

--- a/src/server/project-manager.ts
+++ b/src/server/project-manager.ts
@@ -1,6 +1,6 @@
 import { Log } from "../util/log"
 import { OpencodeClient, createOpencodeClient } from "@opencode-ai/sdk/client"
-import { execSync, exec } from "child_process"
+import { execFile } from "child_process"
 import { promisify } from "util"
 import * as fs from "fs/promises"
 import * as crypto from "crypto"
@@ -146,7 +146,7 @@ export class ProjectManager {
 
   private async ensureConfigDirSync(): Promise<void> {
     try {
-      execSync(`mkdir -p ${this.configDir}`)
+      await fs.mkdir(this.configDir, { recursive: true })
     } catch {
       // Directory might already exist or other error, ignore
     }
@@ -248,9 +248,9 @@ export class ProjectManager {
 
   private async findGitRoot(startPath: string): Promise<string | null> {
     try {
-      const execAsync = promisify(exec)
-      const result = await execAsync(`cd ${startPath} && git rev-parse --show-toplevel`)
-      return result.stdout.trim()
+      const execFileAsync = promisify(execFile)
+      const { stdout } = await execFileAsync("git", ["-C", startPath, "rev-parse", "--show-toplevel"]) 
+      return stdout.toString().trim()
     } catch {
       return null
     }
@@ -258,9 +258,9 @@ export class ProjectManager {
 
   private async getInitialCommitHash(gitRoot: string): Promise<string | null> {
     try {
-      const execAsync = promisify(exec)
-      const result = await execAsync(`cd ${gitRoot} && git rev-list --max-parents=0 HEAD`)
-      const hash = result.stdout.trim().split("\n")[0]
+      const execFileAsync = promisify(execFile)
+      const { stdout } = await execFileAsync("git", ["-C", gitRoot, "rev-list", "--max-parents=0", "HEAD"]) 
+      const hash = stdout.toString().trim().split("\n")[0]
       return hash ? hash.substring(0, 16) : null
     } catch {
       return null


### PR DESCRIPTION
Follow-up to #3 (base: new-setuff).\n\n- Replace shell exec in ProjectManager with execFile and fs.mkdir.\n- Change GitHub cache default to .cache and stop copying data/ in build.\n- Remove committed cache artifacts and rely on .gitignore.\n- Fix README links and clarify dev flow.\n- Minor lint/type tweaks.\n\nBuild + tests pass locally.